### PR TITLE
Add standardized bus registration procedure

### DIFF
--- a/examples/ICE/src/Main.lf
+++ b/examples/ICE/src/Main.lf
@@ -20,7 +20,7 @@ preamble{=
     import yaml
     import math 
     CONFIG_PATH = "models/configuration.yaml"
-    from machine_data_model.protocols.glacier_v1.glacier_message import GlacierMessage, GlacierSpecialMessage
+    from machine_data_model.protocols.glacier_v1.glacier_message import GlacierMessage
     from machine_data_model.protocols.glacier_v1.glacier_header import * 
     from machine_data_model.protocols.glacier_v1.glacier_payload import *
     from machine_data_model.protocols.glacier_v1.glacier_protocol_mng import GlacierProtocolMng

--- a/examples/ICE/src/Scheduler.lf
+++ b/examples/ICE/src/Scheduler.lf
@@ -23,10 +23,32 @@ reactor Scheduler(recipe_path = "../ICE/recipes/test_recipe.yaml",
 
     logical action routine
 
-    reaction(startup)-> channel_out, routine{=
-        message = GlacierSpecialMessage(sender=self.name, target="Bus", identifier=uuid.uuid4(), header=SpecialHeader.INIT_HANDSHAKE)
+    method generate_bus_registration_message(){=
+        """
+        Generates a `REGISTER` message to initiate the registration process with the CommonBus.
 
-        channel_out.set(message)
+        This method constructs a `GlacierMessage` that requests registration in the 
+        communication system. The message is addressed to the `"CommonBus"` and follows 
+        the `PROTOCOL` namespace with the `REGISTER` message name.
+
+        :return: A `GlacierMessage` representing the registration request.
+        """
+        return GlacierMessage(
+            sender=self.name,
+            target="CommonBus",
+            identifier=str(uuid.uuid4()),
+            header=GlacierHeader(
+                type=MsgType.REQUEST,
+                version=(1, 0, 0),
+                namespace=MsgNamespace.PROTOCOL,
+                msg_name=ProtocolMsgName.REGISTER,
+            ),
+            payload=ProtocolPayload(),
+        )
+    =}
+
+    reaction(startup)-> channel_out, routine{=
+        channel_out.set(self.generate_bus_registration_message())
         routine.schedule(SEC(2))
     =}
 
@@ -39,7 +61,12 @@ reactor Scheduler(recipe_path = "../ICE/recipes/test_recipe.yaml",
         messages = channel_in.value
         assert isinstance(messages, list) and all(isinstance(item, Message) for item in messages), f"Received invalid messages: {messages}"
         for message in messages:
-            logging.warning(f"{message.sender} to {message.target} with header {message.header} and payload {message.payload if not isinstance(message, GlacierSpecialMessage) else None}\n")
+            if message.header.matches(MsgType.REQUEST, MsgNamespace.PROTOCOL, ProtocolMsgName.REGISTER):
+                logging.debug(f"{message.sender} requests to register to {message.target}.")
+            if message.header.matches(MsgType.RESPONSE, MsgNamespace.PROTOCOL, ProtocolMsgName.REGISTER):
+                logging.debug(f"{message.sender} notify registration to {message.target}.")
+            else:
+                logging.debug(f"{message.sender} to {message.target} with header {message.header} and payload {message.payload}\n")
         if self.recipe:
             routine.schedule(SEC(2))
     =}

--- a/glacier/src/CommonBus.lf
+++ b/glacier/src/CommonBus.lf
@@ -18,23 +18,43 @@ reactor CommonBus(width = 1){
             self.messages_out[msg.target].append(msg)
     =}
 
-    method append_special_message(message, index){=
+    method register_machine(message, index){=
         '''
-        Handle special messages: 
-        - INIT_HANDSHAKE: Add the sender to the map, and send a response
+        Handles machines that register to the bus (`REGISTER` request).
+
+        - Validates that the message is a proper `PROTOCOL REGISTER` request.
+        - Registers the sender in the communication map.
+        - Ensures the sender has an output queue.
+        - Sends a `REGISTER` response to acknowledge the handshake.
+
+        :param message: The incoming handshake message.
+        :param index: The index representing the sender in the communication list.
         '''
-        assert message.header == SpecialHeader.INIT_HANDSHAKE, f"Invalid special header: {message.header}"
+        assert message.header.matches(MsgType.REQUEST, MsgNamespace.PROTOCOL, ProtocolMsgName.REGISTER), (
+            f"Invalid header: {message.header}"
+        )
+        # Register sender to the map.
         self.map[message.sender] = index
+        # Ensure sender has an output queue.
         if message.sender not in self.messages_out:
             self.messages_out[message.sender] = []
-        self.messages_out[message.sender].append(
-            GlacierSpecialMessage(
-                sender="CommonBus", 
-                target=message.sender, 
-                identifier=uuid.uuid4(), 
-                header=SpecialHeader.INIT_HANDSHAKE
-            )
+        # Generate the correct response.
+        response = GlacierMessage(
+            sender="CommonBus",
+            target=message.sender,
+            identifier=str(uuid.uuid4()),
+            header=GlacierHeader(
+                type=MsgType.RESPONSE,
+                version=(1, 0, 0),
+                namespace=MsgNamespace.PROTOCOL,
+                msg_name=ProtocolMsgName.REGISTER,
+            ),
+            payload=ProtocolPayload(),
         )
+        # Store the response in the sender's queue.
+        self.messages_out[message.sender].append(response)
+        # Log the registrer operation.
+        logging.debug(f"CommonBus register machine {message.sender}, with index {index}.")
     =}
 
     reaction(machine_in)-> machine_out{=
@@ -51,8 +71,10 @@ reactor CommonBus(width = 1){
 
             message = port.value
             if isinstance(message, Message):
-                if isinstance(message.header, SpecialHeader):
-                    self.append_special_message(message, i)                    
+
+                # Handle requests to register to the bus.
+                if message.header.matches(MsgType.REQUEST, MsgNamespace.PROTOCOL, ProtocolMsgName.REGISTER):
+                    self.register_machine(message, i)
                     continue
 
                 assert message.target in self.map, f"Target {message.target} not found in the neighborhood"
@@ -67,7 +89,7 @@ reactor CommonBus(width = 1){
             if not messages:
                 continue
             machine_out[self.map[target]].set(messages)
-            logging.warning(f"CommonBus sent {len(messages)} messages to {target}")
+            logging.debug(f"CommonBus routed {len(messages)} message{'s' if len(messages) > 1 else ''} to {target}")
             self.messages_out[target] = []
             
     =}

--- a/glacier/src/Model.lf
+++ b/glacier/src/Model.lf
@@ -5,7 +5,7 @@ reactor Model(model_path = ""){
     state path = model_path
     state name
     state busy
-    state handshake
+    state registered_to_bus
 
     input  channel_in
     output channel_out
@@ -16,39 +16,65 @@ reactor Model(model_path = ""){
 
     timer check_update(1s, 1s)
     timer work(1s, 1s)
-    logical action check_handshake
+    logical action check_bus_registration
     logical action durable_method
     logical action durable_method_end
     logical action handle_update
 
-    reaction(check_handshake)->channel_out,check_handshake{=
-        '''
-        If the handshake is not completed, send a handshake message to the bus
-        After 9 seconds, raise an exception
-        '''
-        if not self.handshake:
-            if lf.time.logical_elapsed() > SEC(9):
-                raise Exception(f"Handshake failed:{self.name} unable to connect to the bus") 
-            message = GlacierSpecialMessage(sender=self.name, target="Bus", identifier=uuid.uuid4(), header=SpecialHeader.INIT_HANDSHAKE)
-            channel_out.set(message)
-            check_handshake.schedule(SEC(3))
+    method generate_bus_registration_message(){=
+        """
+        Generates a `REGISTER` message to initiate the registration process with the CommonBus.
+
+        This method constructs a `GlacierMessage` that requests registration in the 
+        communication system. The message is addressed to the `"CommonBus"` and follows 
+        the `PROTOCOL` namespace with the `REGISTER` message name.
+
+        :return: A `GlacierMessage` representing the registration request.
+        """
+        return GlacierMessage(
+            sender=self.name,
+            target="CommonBus",
+            identifier=str(uuid.uuid4()),
+            header=GlacierHeader(
+                type=MsgType.REQUEST,
+                version=(1, 0, 0),
+                namespace=MsgNamespace.PROTOCOL,
+                msg_name=ProtocolMsgName.REGISTER,
+            ),
+            payload=ProtocolPayload(),
+        )
     =}
 
-    reaction(startup)-> channel_out,check_handshake{=
+    reaction(check_bus_registration)->channel_out,check_bus_registration{=
+        '''
+        If the registered_to_bus is not completed, send a registered_to_bus message to the bus
+        After 9 seconds, raise an exception
+        '''
+        if not self.registered_to_bus:
+            if lf.time.logical_elapsed() > SEC(9):
+                raise Exception(f"Handshake failed:{self.name} unable to connect to the bus")
+            # Generate and send the bus registration message.
+            channel_out.set(self.generate_bus_registration_message())
+            # Re-schedule the check in 3 seconds.
+            check_bus_registration.schedule(SEC(3))
+    =}
+
+    reaction(startup)-> channel_out,check_bus_registration{=
         '''
         Initialize the model and internal variables
-        Send an initial handshake message to the bus
+        Send an initial registered_to_bus message to the bus
         '''
-        self.handshake = False
+        self.registered_to_bus = False
         self.busy = False
         self.message_queue = []
         self.name = (self.path.split("/")[-1]).split(".")[0]
-        message = GlacierSpecialMessage(sender=self.name, target="Bus", identifier=uuid.uuid4(), header=SpecialHeader.INIT_HANDSHAKE)
-        channel_out.set(message)
-        check_handshake.schedule(SEC(3))
+        # Generate and send the bus registration message.
+        channel_out.set(self.generate_bus_registration_message())
+        # Schedule the check in 3 seconds.
+        check_bus_registration.schedule(SEC(3))
     =}
 
-    reaction(channel_in)->channel_out,check_handshake,durable_method,handle_update{=
+    reaction(channel_in)->channel_out,check_bus_registration,durable_method,handle_update{=
         '''
         Handle incoming messages from the bus
         First check if the message is a durable method, if so, schedule it to be executed
@@ -57,25 +83,25 @@ reactor Model(model_path = ""){
         Once the response is generated, append it to the message queue
         Send the message queue to the bus
         '''
-        message = channel_in.value
-        assert isinstance(message, list) and all(isinstance(item, Message) for item in message), "Expected a list of Message instances"
+        messages = channel_in.value
+        assert isinstance(messages, list) and all(isinstance(item, Message) for item in messages), "Expected a list of Message instances"
 
-        for msg in message:
-            if isinstance(msg, GlacierMessage):
+        for message in messages:
+            if isinstance(message, GlacierMessage):
 
-                if msg.header.namespace == MsgNamespace.METHOD and self.data_model.get_node(msg.payload.node).is_durable():
-                    durable_method.schedule(0, msg)
+                if message.header.namespace == MsgNamespace.METHOD and self.data_model.get_node(message.payload.node).is_durable():
+                    durable_method.schedule(0, message)
 
-                elif msg.header.namespace == MsgNamespace.VARIABLE and VariableMsgName.UPDATE == msg.header.msg_name:
-                    handle_update.schedule(0, msg)
+                elif message.header.namespace == MsgNamespace.VARIABLE and message.header.msg_name == VariableMsgName.UPDATE:
+                    handle_update.schedule(0, message)
 
+                elif message.header.matches(MsgType.RESPONSE, MsgNamespace.PROTOCOL, ProtocolMsgName.REGISTER):
+                    logging.debug(f"Machine {self.name}, correctly registered with the CommonBus.")
+                    self.registered_to_bus = True
+    
                 else:
-                    response_message = self.protocol_mng.handle_message(msg)
+                    response_message = self.protocol_mng.handle_message(message)
                     self.message_queue.append(response_message)
-
-            elif isinstance(msg, GlacierSpecialMessage):
-                assert msg.header == SpecialHeader.INIT_HANDSHAKE, "Handshake failed"
-                self.handshake = True
 
         if self.message_queue:
             channel_out.set(self.message_queue)


### PR DESCRIPTION
## Changes

1. Adds a `generate_bus_registration_message()` function to the `Model`:
  - Creates a `GlacierMessage` of type `REQUEST`, `PROTOCOL` and `REGISTER`.
  - Sends the request to `CommonBus` to register the sender.
2. Add the `register_machine()` to the `CommonBus`:
  - Validates `REGISTER` messages using `GlacierHeader.matches()`.
  - Stores the sender in the communication map.
  - Sends a `RESPONSE` to match the `REQUEST`.

## Overview

Machines can register to the bus by sending:
```
GlacierMessage(
    sender=self.name,
    target="CommonBus",
    identifier=str(uuid.uuid4()),
    header=GlacierHeader(
        version=self._protocol_version,
        type=MsgType.REQUEST,
        namespace=MsgNamespace.PROTOCOL,
        msg_name=ProtocolMsgName.REGISTER,
    ),
    payload=ProtocolPayload(),
)
```

So basically, a `REQUEST` related to the `PROTOCOL` specifically to `REGISTER` to the `CommonBus`.

The `CommonBus` will simply answer with a `RESPONSE` of the same type, to acknowledge the correct registration. That concluded the procedure.